### PR TITLE
Fix Blackfire assertions

### DIFF
--- a/framework/features/bootstrap/BlackfireSingleton.php
+++ b/framework/features/bootstrap/BlackfireSingleton.php
@@ -63,6 +63,7 @@ final class BlackfireSingleton
     public function startBuild(): void
     {
         if ($this->isProfiling) {
+            $this->profileConfig->assert('main.wall_time < 100ms', 'Basic wall time assertion');
             $this->profileConfig->assert('percent(main.wall_time) < 10%', 'Its not slowest');
             $this->profileConfig->assert('percent(main.peak_memory) < 10%', 'Does not consume more memory');
             $title = sprintf(


### PR DESCRIPTION
This PR adds a "simple" assertion (i.e. not using a comparison function) so that Blackfire can evaluate it in a "first off" build.

After the first build, comparison functions will then be correctly evaluated (Blackfire will have something to compare to).
Usually, you have a majority of "regular" assertions, and fewer comparison ones.
